### PR TITLE
fix: char turn into wrong

### DIFF
--- a/lib-ts-old/go-languageclient.ts
+++ b/lib-ts-old/go-languageclient.ts
@@ -21,7 +21,7 @@ export class GoLanguageClient extends AutoLanguageClient {
     public async getFileCodeFormat(editor: TextEditor): Promise<atomIde.TextEdit[]> {
         let formatTool = this.go.tool(util.getPluginConfigValue('formatTool'), [...util.getPluginConfigValue('formatOptions')])
         let newText = ''
-        formatTool.stdout.setEncoding('ascii')
+        formatTool.stdout.setEncoding('utf8')
         formatTool.stdout.on('data', (data) => {
             if (data) {
                 newText += data


### PR DESCRIPTION
Type a word which not include in ASCII , it will be unreadable when you save file formated by goimports